### PR TITLE
Hashtag `#VirtualRide` applies to virtual rides

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ rules:
     "#cx-tyres":
       tyre-front: schwalbe-x-one-3
       tyre-rear: schwalbe-x-one-4
+
   # These temporarily change component assignments whenever the given hashtag
   # appears in the name (not description!) of an activity.
   #
@@ -219,6 +220,12 @@ rules:
   # longer assigns that component, it doesn't result in temporary unassignment
   # whenever that hashtag is used in an activity name. If you need that, use a
   # dummy component id.
+
+  # A special virtual hashtag `#VirtualRide` can be used to define component
+  # assignements for indoor trainer rides from Zwift, Rouvy, etc.
+  - "#VirtualRide":
+      tyre-front: wahoo-kickr-climb
+      tyre-rear: wahoo-kickr
 
   # Dates are interpreted as midnight in your current time zone.
   # Time can be specified too, if you swapped components in between rides in

--- a/src/strava_gear/core.py
+++ b/src/strava_gear/core.py
@@ -5,6 +5,7 @@ from typing import Iterable
 from typing import List
 from warnings import warn
 
+from .data import HashTag
 from .data import Result
 from .data import Rule
 from .data import Rules
@@ -38,7 +39,11 @@ def apply_rules(rules: Rules, activities: List[Dict]) -> Result:
 def usage_for_activity(activity: Dict, rule: Rule) -> Usage:
     component_map = rule.bikes.get(activity['gear_id'], {})
 
-    for hashtag in (s for s in activity['name'].split() if s.startswith('#')):
+    hashtags = [s for s in activity['name'].split() if s.startswith('#')]
+    if activity['type'] == 'VirtualRide':
+        hashtags.append(HashTag('#VirtualRide'))
+
+    for hashtag in hashtags:
         component_map_ht = rule.hashtags.get(hashtag)
         if component_map_ht:
             component_map = {**component_map, **component_map_ht}

--- a/src/strava_gear/input/activities.py
+++ b/src/strava_gear/input/activities.py
@@ -23,7 +23,7 @@ def read_input_csv(inp) -> Tuple[Dict[BikeName, BikeId], List[Dict]]:
     """
     activities: List[Dict] = []
     for r in csv.DictReader(inp):
-        assert r.keys() <= {'name', 'gear_id', 'start_date', 'moving_time', 'distance'}
+        assert r.keys() <= {'name', 'gear_id', 'type', 'start_date', 'moving_time', 'distance'}
         activities.append({
             **r,
             'moving_time': int(r['moving_time']),
@@ -47,8 +47,8 @@ def read_strava_offline(db_filename: Union[str, PathLike]) -> Tuple[Dict[BikeNam
         }
 
         activities: List[Dict] = []
-        for r in db.execute('SELECT name, gear_id, start_date, moving_time, distance FROM activity'):
-            assert set(r.keys()) <= {'name', 'gear_id', 'start_date', 'moving_time', 'distance'}
+        for r in db.execute('SELECT name, gear_id, type, start_date, moving_time, distance FROM activity'):
+            assert set(r.keys()) <= {'name', 'gear_id', 'type', 'start_date', 'moving_time', 'distance'}
             activities.append({**r, 'start_date': parse_datetime(r['start_date'])})
 
         return aliases, activities


### PR DESCRIPTION
Partially implements trainer rides in https://github.com/liskin/strava-gear/issues/2.

Same as other hashtag values, dummy placeholder IDs must be used to indicate removed/unused components, such as front wheel/tire.