### PR TITLE
Add elevation_gain metric for components

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ For a real life example, take a look at [my own rules.yaml](https://github.com/l
       --rules FILENAME                Rules configuration (bikes, components, ...)  [default:
                                       /home/user/.config/strava_gear/rules.yaml]
       --csv FILENAME                  Load activities from CSV instead of the strava-offline database (columns: name,
-                                      gear_id, start_date, moving_time, distance)
+                                      gear_id, start_date, moving_time, distance, total_elevation_gain)
       --strava-database PATH          Location of the strava-offline database  [default:
                                       /home/user/.local/share/strava_offline/strava.sqlite]
       -o, --output FILENAME           Output file  [default: -]
@@ -292,6 +292,7 @@ For a real life example, take a look at [my own rules.yaml](https://github.com/l
       --show-name / --hide-name       Show long component names  [default: show-name]
       --show-first-last / --hide-first-last
                                       Show first/last usage of components  [default: show-first-last]
+      --show-vert-m / --hide-vert-m   Show vertical meters (elevation gain)  [default: hide-vert-m]
       --help                          Show this message and exit.
 <!-- end include -->
 

--- a/src/strava_gear/cli.py
+++ b/src/strava_gear/cli.py
@@ -23,7 +23,7 @@ from .report import reports
     '--csv', type=click.File('r'),
     help="""
     Load activities from CSV instead of the strava-offline database
-    (columns: name, gear_id, start_date, moving_time, distance)
+    (columns: name, gear_id, start_date, moving_time, distance, total_elevation_gain)
     """)
 @click.option(
     '--strava-database', type=click.Path(path_type=Path),  # type: ignore [type-var] # debian typeshed compat
@@ -49,6 +49,9 @@ from .report import reports
 @click.option(
     '--show-first-last/--hide-first-last', default=True, show_default=True,
     help="Show first/last usage of components")
+@click.option(
+    '--show-vert-m/--hide-vert-m', default=False, show_default=True,
+    help="Show vertical meters (elevation gain)")
 def main(
     rules_input: TextIO,
     csv: Optional[TextIO],
@@ -58,6 +61,7 @@ def main(
     tablefmt: str,
     show_name: bool,
     show_first_last: bool,
+    show_vert_m: bool,
 ):
     if csv:
         aliases, activities = read_input_csv(csv)
@@ -65,7 +69,13 @@ def main(
         aliases, activities = read_strava_offline(strava_database)
     rules = read_rules(rules_input, aliases=aliases)
     res = apply_rules(rules, activities)
-    reports[report](res, output=output, tablefmt=tablefmt, show_name=show_name, show_first_last=show_first_last)
+    reports[report](
+        res,
+        output=output, tablefmt=tablefmt,
+        show_name=show_name,
+        show_first_last=show_first_last,
+        show_vert_m=show_vert_m,
+    )
     warn_unknown_bikes(rules, activities)
 
 

--- a/src/strava_gear/core.py
+++ b/src/strava_gear/core.py
@@ -53,6 +53,7 @@ def usage_for_activity(activity: Dict, rule: Rule) -> Usage:
     return Usage.from_activity(
         components=component_map.values(),
         distance=activity['distance'],
+        elevation_gain=activity['total_elevation_gain'],
         time=activity['moving_time'],
         ts=activity['start_date'])
 

--- a/src/strava_gear/data.py
+++ b/src/strava_gear/data.py
@@ -87,6 +87,7 @@ class Component:
     ident: ComponentId
     name: ComponentName
     distance: Meters = Meters(0.0)
+    elevation_gain: Meters = Meters(0.0)
     time: Seconds = Seconds(0.0)
     firstlast: FirstLast = FirstLast()
     assignment: Optional[ComponentAssignment] = None
@@ -95,6 +96,7 @@ class Component:
         return replace(
             self,
             distance=Meters(self.distance + usage.distances.get(self.ident, 0)),
+            elevation_gain=Meters(self.elevation_gain + usage.elevation_gains.get(self.ident, 0)),
             time=Seconds(self.time + usage.times.get(self.ident, 0)),
             firstlast=self.firstlast + usage.firstlasts.get(self.ident, FirstLast()))
 
@@ -164,14 +166,22 @@ class Rules:
 @dataclass
 class Usage:
     distances: Dict[ComponentId, float] = field(default_factory=lambda: defaultdict(float))
+    elevation_gains: Dict[ComponentId, float] = field(default_factory=lambda: defaultdict(float))
     times: Dict[ComponentId, float] = field(default_factory=lambda: defaultdict(float))
     firstlasts: Dict[ComponentId, FirstLast] = field(default_factory=lambda: defaultdict(FirstLast))
 
     @staticmethod
-    def from_activity(components: Iterable[ComponentId], distance: float, time: float, ts: datetime):
+    def from_activity(
+        components: Iterable[ComponentId],
+        distance: float,
+        elevation_gain: float,
+        time: float,
+        ts: datetime,
+    ):
         fl = FirstLast.from_ts(ts)
         return Usage(
             distances={c: distance for c in components},
+            elevation_gains={c: elevation_gain for c in components},
             times={c: time for c in components},
             firstlasts={c: fl for c in components})
 
@@ -180,6 +190,8 @@ class Usage:
             return NotImplemented
         for k, d in other.distances.items():
             self.distances[k] += d
+        for k, d in other.elevation_gains.items():
+            self.elevation_gains[k] += d
         for k, t in other.times.items():
             self.times[k] += t
         for k, fl in other.firstlasts.items():

--- a/src/strava_gear/input/activities.py
+++ b/src/strava_gear/input/activities.py
@@ -16,6 +16,7 @@ essential_columns = {
     'start_date',
     'moving_time',
     'distance',
+    'total_elevation_gain',
 }
 
 
@@ -26,7 +27,7 @@ def read_input_csv(inp) -> Tuple[Dict[BikeName, BikeId], List[Dict]]:
         sqlite3 ~/.local/share/strava_offline/strava.sqlite \
             ".mode csv" \
             ".headers on" \
-            "SELECT name, gear_id, start_date, moving_time, distance FROM activity" \
+            "SELECT name, gear_id, start_date, moving_time, distance, total_elevation_gain FROM activity" \
             >activities.csv
     """
     activities: List[Dict] = []
@@ -36,6 +37,7 @@ def read_input_csv(inp) -> Tuple[Dict[BikeName, BikeId], List[Dict]]:
             **r,
             'moving_time': int(r['moving_time']),
             'distance': float(r['distance']),
+            'total_elevation_gain': float(r['total_elevation_gain']),
             'start_date': parse_datetime(r['start_date']),
         })
 

--- a/src/strava_gear/report.py
+++ b/src/strava_gear/report.py
@@ -12,12 +12,14 @@ from .data import FirstLast
 from .data import Result
 
 
-def report(f, res: Result, output, tablefmt: str, show_name: bool, show_first_last: bool):
+def report(f, res: Result, output, tablefmt: str, show_name: bool, show_first_last: bool, show_vert_m: bool):
     def cols(d: Dict) -> Dict:
         if not show_name:
             del d["name"]
         if not show_first_last:
             del d["first … last"]
+        if not show_vert_m:
+            del d["vert m"]
         return d
 
     table = [cols(d) for d in f(res)]
@@ -38,6 +40,7 @@ def report_components(res: Result) -> Iterator[Dict]:
             "id": c.ident,
             "name": c.name,
             "km": c.distance / 1000,
+            "vert m": c.elevation_gain,
             "hour": c.time / 3600,
             "first … last": c.firstlast,
         }
@@ -61,6 +64,7 @@ def report_bikes(res: Result, show_names: bool = True, show_firstlasts: bool = T
             "id": c.ident,
             "name": c.name,
             "km": c.distance / 1000,
+            "vert m": c.elevation_gain,
             "hour": c.time / 3600,
             "first … last": c.firstlast,
         }

--- a/tests/csv.md
+++ b/tests/csv.md
@@ -25,10 +25,10 @@ Rules:
 Bikes report:
 
     $ strava-gear <<END
-    > name,gear_id,start_date,moving_time,distance
-    > Ride 1,road,2022-01-01,3600,1000
-    > Ride 2,road,2023-01-01,3600,1000
-    > Ride 3,road,2023-02-01,3600,1000
+    > name,gear_id,start_date,moving_time,distance,total_elevation_gain
+    > Ride 1,road,2022-01-01,3600,1000,10
+    > Ride 2,road,2023-01-01,3600,1000,10
+    > Ride 3,road,2023-02-01,3600,1000,10
     > END
     bike,role,id,name,km,hour,first … last
     road,chain,c3,c3,0.0,0.0,never
@@ -36,10 +36,10 @@ Bikes report:
 Components report:
 
     $ strava-gear --report components <<END
-    > name,gear_id,start_date,moving_time,distance
-    > Ride 1,road,2022-01-01,3600,1000
-    > Ride 2,road,2023-01-01,3600,1000
-    > Ride 3,road,2023-02-01,3600,1000
+    > name,gear_id,start_date,moving_time,distance,total_elevation_gain
+    > Ride 1,road,2022-01-01,3600,1000,10
+    > Ride 2,road,2023-01-01,3600,1000,10
+    > Ride 3,road,2023-02-01,3600,1000,10
     > END
     id,name,km,hour,first … last
     c3,c3,0.0,0.0,never
@@ -51,10 +51,10 @@ Components report:
 VirtualRide virtual hashtag:
 
     $ strava-gear --report components <<END
-    > name,gear_id,start_date,moving_time,distance,type
-    > Ride 1,road,2022-01-01,3600,1000,Ride
-    > Ride 2,road,2023-01-01,3600,1000,Ride
-    > Ride 4,road,2023-02-01,3600,1000,VirtualRide
+    > name,gear_id,start_date,moving_time,distance,total_elevation_gain,type
+    > Ride 1,road,2022-01-01,3600,1000,10,Ride
+    > Ride 2,road,2023-01-01,3600,1000,10,Ride
+    > Ride 4,road,2023-02-01,3600,1000,10,VirtualRide
     > END
     id,name,km,hour,first … last
     c3,c3,0.0,0.0,never

--- a/tests/readme/cmdline.md
+++ b/tests/readme/cmdline.md
@@ -9,7 +9,7 @@
       --rules FILENAME                Rules configuration (bikes, components, ...)  [default:
                                       /home/user/.config/strava_gear/rules.yaml]
       --csv FILENAME                  Load activities from CSV instead of the strava-offline database (columns: name,
-                                      gear_id, start_date, moving_time, distance)
+                                      gear_id, start_date, moving_time, distance, total_elevation_gain)
       --strava-database PATH          Location of the strava-offline database  [default:
                                       /home/user/.local/share/strava_offline/strava.sqlite]
       -o, --output FILENAME           Output file  [default: -]
@@ -20,4 +20,5 @@
       --show-name / --hide-name       Show long component names  [default: show-name]
       --show-first-last / --hide-first-last
                                       Show first/last usage of components  [default: show-first-last]
+      --show-vert-m / --hide-vert-m   Show vertical meters (elevation gain)  [default: hide-vert-m]
       --help                          Show this message and exit.


### PR DESCRIPTION
In search for a tool helping evaluate braking components wear, I've added elevation_gain reporting as a proxy for the amount of braking over time.

Rationale for this approach is that more elevation gain will, most of the time, imply also elevation loss and thus braking.

Further enhancement can be implemented extracting more data from Strava splits, as detailed here: https://groups.google.com/g/strava-api/c/rBYiuBFNzUE