### PR TITLE
Add support for imperial display.

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,8 @@ For a real life example, take a look at [my own rules.yaml](https://github.com/l
       --show-name / --hide-name       Show long component names  [default: show-name]
       --show-first-last / --hide-first-last
                                       Show first/last usage of components  [default: show-first-last]
-      --show-vert-m / --hide-vert-m   Show vertical meters (elevation gain)  [default: hide-vert-m]
+      --show-vert / --hide-vert       Show vertical (elevation gain)  [default: hide-vert]
+      --units [metric|imperial]       Show data in metric or imperial  [default: metric]
       --help                          Show this message and exit.
 <!-- end include -->
 

--- a/src/strava_gear/cli.py
+++ b/src/strava_gear/cli.py
@@ -51,8 +51,11 @@ from .report import reports
     '--show-first-last/--hide-first-last', default=True, show_default=True,
     help="Show first/last usage of components")
 @click.option(
-    '--show-vert-m/--hide-vert-m', default=False, show_default=True,
-    help="Show vertical meters (elevation gain)")
+    '--show-vert/--hide-vert', default=False, show_default=True,
+    help="Show vertical (elevation gain)")
+@click.option(
+    '--units', type=click.Choice(["metric", "imperial"]), default="metric", show_default=True,
+    help="Show data in metric or imperial")
 def main(
     rules_input: TextIO,
     csv: Optional[TextIO],
@@ -62,7 +65,8 @@ def main(
     tablefmt: str,
     show_name: bool,
     show_first_last: bool,
-    show_vert_m: bool,
+    show_vert: bool,
+    units: str,
 ):
     if csv:
         aliases, activities = read_input_csv(csv)
@@ -75,7 +79,8 @@ def main(
         output=output, tablefmt=tablefmt,
         show_name=show_name,
         show_first_last=show_first_last,
-        show_vert_m=show_vert_m,
+        show_vert=show_vert,
+        units=units,
     )
     warn_unknown_bikes(rules, activities)
 

--- a/src/strava_gear/report.py
+++ b/src/strava_gear/report.py
@@ -12,14 +12,22 @@ from .data import FirstLast
 from .data import Result
 
 
-def report(f, res: Result, output, tablefmt: str, show_name: bool, show_first_last: bool, show_vert_m: bool):
+def report(f, res: Result, output, tablefmt: str, show_name: bool, show_first_last: bool, show_vert: bool, units: str):
     def cols(d: Dict) -> Dict:
         if not show_name:
             del d["name"]
         if not show_first_last:
             del d["first … last"]
-        if not show_vert_m:
+        if units == "imperial":
+            del d["km"]
             del d["vert m"]
+            if not show_vert:
+                del d["vert ft"]
+        else:
+            del d["mi"]
+            del d["vert ft"]
+            if not show_vert:
+                del d["vert m"]
         return d
 
     table = [cols(d) for d in f(res)]
@@ -40,7 +48,9 @@ def report_components(res: Result) -> Iterator[Dict]:
             "id": c.ident,
             "name": c.name,
             "km": c.distance / 1000,
+            "mi": c.distance / 1000*0.62,
             "vert m": c.elevation_gain,
+            "vert ft": c.elevation_gain*3.3,
             "hour": c.time / 3600,
             "first … last": c.firstlast,
         }
@@ -64,7 +74,9 @@ def report_bikes(res: Result) -> Iterator[Dict]:
             "id": c.ident,
             "name": c.name,
             "km": c.distance / 1000,
+            "mi": c.distance / 1000*0.62,
             "vert m": c.elevation_gain,
+            "vert ft": c.elevation_gain*3.3,
             "hour": c.time / 3600,
             "first … last": c.firstlast,
         }

--- a/tests/csv.md
+++ b/tests/csv.md
@@ -62,3 +62,18 @@ VirtualRide virtual hashtag:
     c1,c1,1.0,1.0,2022-01-01 … 2022-01-01
     c2,c2,1.0,1.0,2023-01-01 … 2023-01-01
     c5,c5,1.0,1.0,2023-02-01 … 2023-02-01
+
+Components report imperial:
+
+    $ strava-gear --report components --units imperial <<END
+    > name,gear_id,start_date,moving_time,distance,total_elevation_gain
+    > Ride 1,road,2022-01-01,3600,1000,10
+    > Ride 2,road,2023-01-01,3600,1000,10
+    > Ride 3,road,2023-02-01,3600,1000,10
+    > END
+    id,name,mi,hour,first … last
+    c3,c3,0.0,0.0,never
+    c5,c5,0.0,0.0,never
+    c1,c1,0.62,1.0,2022-01-01 … 2022-01-01
+    c2,c2,0.62,1.0,2023-01-01 … 2023-01-01
+    c4,c4,0.62,1.0,2023-02-01 … 2023-02-01

--- a/tests/readme/cmdline.md
+++ b/tests/readme/cmdline.md
@@ -20,5 +20,6 @@
       --show-name / --hide-name       Show long component names  [default: show-name]
       --show-first-last / --hide-first-last
                                       Show first/last usage of components  [default: show-first-last]
-      --show-vert-m / --hide-vert-m   Show vertical meters (elevation gain)  [default: hide-vert-m]
+      --show-vert / --hide-vert       Show vertical (elevation gain)  [default: hide-vert]
+      --units [metric|imperial]       Show data in metric or imperial  [default: metric]
       --help                          Show this message and exit.


### PR DESCRIPTION
Add `--units` option to list of arguments to add support for displaying metrics in either metric (default) or imperial.

