### PR TITLE
Add start and end boundaries to activity list

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,9 @@ For a real life example, take a look at [my own rules.yaml](https://github.com/l
                                       Show first/last usage of components  [default: show-first-last]
       --show-vert / --hide-vert       Show vertical (elevation gain)  [default: hide-vert]
       --units [metric|imperial]       Show data in metric or imperial  [default: metric]
+      --date-start [%Y-%m-%d|%d-%m-%Y]
+                                      Start from date
+      --date-end [%Y-%m-%d|%d-%m-%Y]  Up to date
       --help                          Show this message and exit.
 <!-- end include -->
 

--- a/src/strava_gear/cli.py
+++ b/src/strava_gear/cli.py
@@ -1,7 +1,7 @@
+from datetime import datetime
 from pathlib import Path
 from typing import Optional
 from typing import TextIO
-from datetime import datetime
 
 import click
 import platformdirs
@@ -11,10 +11,10 @@ from .core import warn_unknown_bikes
 from .input.activities import essential_columns
 from .input.activities import read_input_csv
 from .input.activities import read_strava_offline
+from .input.date import parse_datetime
 from .input.rules import read_rules
 from .report import Units
 from .report import reports
-from .input.date import parse_datetime
 
 
 @click.command(context_settings={'max_content_width': 120})

--- a/src/strava_gear/cli.py
+++ b/src/strava_gear/cli.py
@@ -60,11 +60,11 @@ from .report import reports
     callback=lambda _ctx, _param, v: Units[v.upper()],  # TODO: drop when Python 3.11 is the oldest supported
     help="Show data in metric or imperial")
 @click.option(
-    '--date-start', type=click.DateTime(formats=["%Y-%m-%d","%d-%m-%Y"]),
+    '--date-start', type=click.DateTime(formats=["%Y-%m-%d", "%d-%m-%Y"]),
     default=str("1970-01-01"),
     help="Start from date")
 @click.option(
-    '--date-end', type=click.DateTime(formats=["%Y-%m-%d","%d-%m-%Y"]),
+    '--date-end', type=click.DateTime(formats=["%Y-%m-%d", "%d-%m-%Y"]),
     default=str("2100-01-01"),
     help="Up to date")
 def cli(
@@ -85,8 +85,8 @@ def cli(
         aliases, activities = read_input_csv(csv)
     else:
         aliases, activities = read_strava_offline(strava_database)
-    date_start=date_start.date()
-    date_end=date_end.date()
+    date_start = date_start.date()
+    date_end = date_end.date()
     rules = read_rules(rules_input, aliases=aliases)
     res = apply_rules(rules, activities, date_start, date_end)
     reports[report](

--- a/src/strava_gear/cli.py
+++ b/src/strava_gear/cli.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Optional
 from typing import TextIO
-from datetime import date
+from datetime import datetime
 
 import click
 import platformdirs
@@ -14,6 +14,7 @@ from .input.activities import read_strava_offline
 from .input.rules import read_rules
 from .report import Units
 from .report import reports
+from .input.date import parse_datetime
 
 
 @click.command(context_settings={'max_content_width': 120})
@@ -78,15 +79,15 @@ def cli(
     show_first_last: bool,
     show_vert: bool,
     units: Units,
-    date_start: date,
-    date_end: date
+    date_start: Optional[datetime],
+    date_end: Optional[datetime]
 ):
     if csv:
         aliases, activities = read_input_csv(csv)
     else:
         aliases, activities = read_strava_offline(strava_database)
-    date_start = date_start.date()
-    date_end = date_end.date()
+    date_start = parse_datetime(date_start)
+    date_end = parse_datetime(date_end)
     rules = read_rules(rules_input, aliases=aliases)
     res = apply_rules(rules, activities, date_start, date_end)
     reports[report](

--- a/src/strava_gear/core.py
+++ b/src/strava_gear/core.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from itertools import accumulate
 from itertools import chain
 from typing import Dict
@@ -5,7 +6,6 @@ from typing import Iterable
 from typing import List
 from typing import Optional
 from warnings import warn
-from datetime import datetime
 
 from .data import HashTag
 from .data import Result

--- a/src/strava_gear/core.py
+++ b/src/strava_gear/core.py
@@ -3,8 +3,9 @@ from itertools import chain
 from typing import Dict
 from typing import Iterable
 from typing import List
+from typing import Optional
 from warnings import warn
-from datetime import date
+from datetime import datetime
 
 from .data import HashTag
 from .data import Result
@@ -13,7 +14,9 @@ from .data import Rules
 from .data import Usage
 
 
-def apply_rules(rules: Rules, activities: List[Dict], date_start: date, date_end: date) -> Result:
+def apply_rules(rules: Rules, activities: List[Dict],
+                date_start: Optional[datetime],
+                date_end: Optional[datetime]) -> Result:
     rules_sorted = sorted(rules.rules, key=lambda r: r.since)
     activities_sorted = sorted(activities, key=lambda a: a['start_date'])
 
@@ -22,10 +25,10 @@ def apply_rules(rules: Rules, activities: List[Dict], date_start: date, date_end
     effective_rules = list(accumulate(chain([Rule()], rules_sorted)))
 
     # If a date boundary is defined, filter the activity list
-    activities_sorted = filter(
-        lambda a: (a['start_date'].date() > date_start) & (a['start_date'].date() < date_end),
+    activities_sorted = list(filter(
+        lambda a: (a['start_date'] > date_start) & (a['start_date'] < date_end),
         activities_sorted
-    )
+    ))
 
     # Determine the effective rules for each activity by merging the two sorted series,
     # and tally up usage.

--- a/src/strava_gear/core.py
+++ b/src/strava_gear/core.py
@@ -22,7 +22,10 @@ def apply_rules(rules: Rules, activities: List[Dict], date_start: date, date_end
     effective_rules = list(accumulate(chain([Rule()], rules_sorted)))
 
     # If a date boundary is defined, filter the activity list
-    activities_sorted = filter(lambda a: (a['start_date'].date() > date_start) & (a['start_date'].date() < date_end), activities_sorted)
+    activities_sorted = filter(
+        lambda a: (a['start_date'].date() > date_start) & (a['start_date'].date() < date_end),
+        activities_sorted
+    )
 
     # Determine the effective rules for each activity by merging the two sorted series,
     # and tally up usage.

--- a/src/strava_gear/core.py
+++ b/src/strava_gear/core.py
@@ -4,6 +4,7 @@ from typing import Dict
 from typing import Iterable
 from typing import List
 from warnings import warn
+from datetime import date
 
 from .data import HashTag
 from .data import Result
@@ -12,13 +13,16 @@ from .data import Rules
 from .data import Usage
 
 
-def apply_rules(rules: Rules, activities: List[Dict]) -> Result:
+def apply_rules(rules: Rules, activities: List[Dict], date_start: date, date_end: date) -> Result:
     rules_sorted = sorted(rules.rules, key=lambda r: r.since)
     activities_sorted = sorted(activities, key=lambda a: a['start_date'])
 
     # Determine the effective combinations of rules for all time points where rules change.
     # Rules effective at time T are obtained by combining all rules up to and including time T.
     effective_rules = list(accumulate(chain([Rule()], rules_sorted)))
+
+    # If a date boundary is defined, filter the activity list
+    activities_sorted = filter(lambda a: (a['start_date'].date() > date_start) & (a['start_date'].date() < date_end), activities_sorted)
 
     # Determine the effective rules for each activity by merging the two sorted series,
     # and tally up usage.

--- a/tests/readme/help.md
+++ b/tests/readme/help.md
@@ -22,4 +22,7 @@
                                       Show first/last usage of components  [default: show-first-last]
       --show-vert / --hide-vert       Show vertical (elevation gain)  [default: hide-vert]
       --units [metric|imperial]       Show data in metric or imperial  [default: metric]
+      --date-start [%Y-%m-%d|%d-%m-%Y]
+                                      Start from date
+      --date-end [%Y-%m-%d|%d-%m-%Y]  Up to date
       --help                          Show this message and exit.


### PR DESCRIPTION
Hi,

I've added a couple of cmdline options to limit the range of dates included in reports. This way, strava_gear can be used to build yearly statistics or tracking usage since, for example, rewaxing a chain.

I've added the filter to the apply_rule function, another approach could have been applying the filter while loading data from sqlite or CSV.

Best,

L