### PR TITLE
Python 3.13 support

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -25,6 +25,7 @@ jobs:
           - '3.10'
           - '3.11'
           - '3.12'
+          - '3.13'
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [ # https://pypi.org/classifiers/
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Utilities",
 ]
 requires-python = "~= 3.8"


### PR DESCRIPTION
Hi, this PR simply adds python3.13 to CI and adds the 3.13 classifier to the package.

Another thing to consider is dropping python3.8 support, since that version has [reached end-of-life already](https://devguide.python.org/versions/) - but it's not really blocking anything.