### PR TITLE
Add multi-bike component assignment (shared components)

### DIFF
--- a/src/strava_gear/core.py
+++ b/src/strava_gear/core.py
@@ -29,7 +29,7 @@ def apply_rules(rules: Rules, activities: List[Dict]) -> Result:
     # Fill computed data (usage, current assignment) into components.
     component_assignments = effective_rules[-1].component_assignments()
     components = [
-        c.add_usage(usage).assign(component_assignments.get(c.ident, None))
+        c.add_usage(usage).assign(component_assignments.get(c.ident, []))
         for c in rules.components
     ]
 

--- a/src/strava_gear/data.py
+++ b/src/strava_gear/data.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import Counter
 from collections import defaultdict
 from dataclasses import dataclass
 from dataclasses import field
@@ -103,7 +104,7 @@ class Component:
     elevation_gain: Meters = Meters(0.0)
     time: Seconds = Seconds(0.0)
     firstlast: FirstLast = FirstLast()
-    assignment: Optional[ComponentAssignment] = None
+    assignments: List[ComponentAssignment] = field(default_factory=list)
 
     def add_usage(self, usage: Usage) -> Component:
         return replace(
@@ -113,8 +114,8 @@ class Component:
             time=Seconds(self.time + usage.times.get(self.ident, 0)),
             firstlast=self.firstlast + usage.firstlasts.get(self.ident, FirstLast()))
 
-    def assign(self, assignment: Optional[ComponentAssignment]) -> Component:
-        return replace(self, assignment=assignment)
+    def assign(self, assignments: List[ComponentAssignment]) -> Component:
+        return replace(self, assignments=assignments)
 
 
 @dataclass(frozen=True)
@@ -128,20 +129,32 @@ class Rule:
         Combine two rules. The second rule's since must be equal or later than the first.
         Component mappings in the second rule then override those in the first.
         Additionally, components newly assigned to another bike are automatically removed
-        from the old one.
+        from the old one, unless they appear on multiple bikes in the new rule (shared).
         """
         if not isinstance(other, Rule):
             return NotImplemented
         if other.since < self.since:
             return NotImplemented
 
-        other_components = {c for m in other.bikes.values() for c in m.values()}
-        bikes = prune_mapping(update_mappings(filter_mapping(self.bikes, other_components), other.bikes))
+        # Find components that appear on multiple bikes in the new rule (shared)
+        other_component_counts = Counter(c for m in other.bikes.values() for c in m.values() if c)
+        shared_in_other = {c for c, count in other_component_counts.items() if count > 1}
+
+        # Only filter out non-shared components from old bikes
+        other_components = set(other_component_counts.keys())
+        components_to_filter = other_components - shared_in_other
+
+        bikes = prune_mapping(update_mappings(filter_mapping(self.bikes, components_to_filter), other.bikes))
         hashtags = prune_mapping(update_mappings(self.hashtags, other.hashtags))
         return replace(other, bikes=bikes, hashtags=hashtags)
 
-    def component_assignments(self) -> Dict[ComponentId, ComponentAssignment]:
-        return {c: ComponentAssignment(b, t) for b, m in self.bikes.items() for t, c in m.items()}
+    def component_assignments(self) -> Dict[ComponentId, List[ComponentAssignment]]:
+        result: Dict[ComponentId, List[ComponentAssignment]] = defaultdict(list)
+        for bike_id, component_map in self.bikes.items():
+            for role, component_id in component_map.items():
+                if component_id is not None:
+                    result[component_id].append(ComponentAssignment(bike_id, role))
+        return dict(result)
 
     def all_component_ids(self) -> Iterator[ComponentId]:
         """Return all component ids mentioned in this rule."""

--- a/src/strava_gear/input/rules.py
+++ b/src/strava_gear/input/rules.py
@@ -133,10 +133,12 @@ def check_component_duplicities(bikes: Mapping[BikeId] = {}, hashtags: Mapping[H
             if c is not None and count > 1:
                 duplicates.add(c)
 
-    # no component may be assigned to multiple roles or bikes
-    for c, count in Counter(c for cm in bikes.values() for c in cm.values()).items():
-        if c is not None and count > 1:
-            duplicates.add(c)
+    # no component may be assigned to multiple roles on the SAME bike
+    # (cross-bike assignment is now allowed for shared components)
+    for bike_id, cm in bikes.items():
+        for c, count in Counter(cm.values()).items():
+            if c is not None and count > 1:
+                duplicates.add(c)
 
     return duplicates
 

--- a/src/strava_gear/report.py
+++ b/src/strava_gear/report.py
@@ -11,7 +11,6 @@ from typing import Iterator
 from tabulate import tabulate
 
 from .data import BikeId
-from .data import Component
 from .data import FirstLast
 from .data import Result
 
@@ -81,22 +80,22 @@ def report_components(res: Result, **_kwargs) -> Iterator[Dict]:
 def report_bikes(res: Result, show_bike: Callable[[BikeId], bool]) -> Iterator[Dict]:
     bikes_firstlasts = bikes_firstlast(res)
 
-    def sort_key(c: Component):
-        assert c.assignment
-        return bikes_firstlasts[c.assignment.bike], c.assignment
+    def sort_key(item: tuple):
+        c, assignment = item
+        return bikes_firstlasts[assignment.bike], assignment
 
-    for c in sorted((
-            c
-            for c in res.components
-            if c.assignment
-            if show_bike(c.assignment.bike)
-        ),
-        key=sort_key
-    ):
-        assert c.assignment
+    # Generate (component, assignment) pairs for all assignments
+    items = [
+        (c, assignment)
+        for c in res.components
+        for assignment in c.assignments
+        if show_bike(assignment.bike)
+    ]
+
+    for c, assignment in sorted(items, key=sort_key):
         yield {
-            "bike": res.bike_names.get(c.assignment.bike, c.assignment.bike),
-            "role": c.assignment.role,
+            "bike": res.bike_names.get(assignment.bike, assignment.bike),
+            "role": assignment.role,
             "id": c.ident,
             "name": c.name,
             "km": c.distance / 1000,
@@ -111,8 +110,8 @@ def report_bikes(res: Result, show_bike: Callable[[BikeId], bool]) -> Iterator[D
 def bikes_firstlast(res: Result) -> Dict[BikeId, FirstLast]:
     fl: Dict[BikeId, FirstLast] = defaultdict(FirstLast)
     for c in res.components:
-        if c.assignment:
-            fl[c.assignment.bike] += c.firstlast
+        for assignment in c.assignments:
+            fl[assignment.bike] += c.firstlast
     return fl
 
 

--- a/tests/shared_components.md
+++ b/tests/shared_components.md
@@ -1,0 +1,85 @@
+Common invocation flags:
+
+    $ function strava-gear {
+    >   command strava-gear --rules rules.yaml --csv - --tablefmt csv "$@"
+    > }
+
+Rules with shared component (same pedals on both bikes in the same rule):
+
+    $ cat >rules.yaml <<END
+    > rules:
+    >   - road:
+    >       pedals: shared-pedals
+    >       chain: road-chain
+    >     gravel:
+    >       pedals: shared-pedals
+    >       chain: gravel-chain
+    > END
+
+Bikes report - shared component appears on both bikes with combined usage:
+
+    $ strava-gear <<END
+    > name,gear_id,start_date,moving_time,distance,total_elevation_gain
+    > Road Ride,road,2024-01-01,3600,10000,100
+    > Gravel Ride,gravel,2024-01-02,3600,15000,200
+    > END
+    bike,role,id,name,km,hour,first … last
+    gravel,chain,gravel-chain,gravel-chain,15.0,1.0,2024-01-02 … 2024-01-02
+    gravel,pedals,shared-pedals,shared-pedals,25.0,2.0,2024-01-01 … 2024-01-02
+    road,chain,road-chain,road-chain,10.0,1.0,2024-01-01 … 2024-01-01
+    road,pedals,shared-pedals,shared-pedals,25.0,2.0,2024-01-01 … 2024-01-02
+
+Components report - shared component shows total usage from both bikes:
+
+    $ strava-gear --report components <<END
+    > name,gear_id,start_date,moving_time,distance,total_elevation_gain
+    > Road Ride,road,2024-01-01,3600,10000,100
+    > Gravel Ride,gravel,2024-01-02,3600,15000,200
+    > END
+    id,name,km,hour,first … last
+    road-chain,road-chain,10.0,1.0,2024-01-01 … 2024-01-01
+    shared-pedals,shared-pedals,25.0,2.0,2024-01-01 … 2024-01-02
+    gravel-chain,gravel-chain,15.0,1.0,2024-01-02 … 2024-01-02
+
+Stop sharing - remove from one bike with null:
+
+    $ cat >rules.yaml <<END
+    > rules:
+    >   - road:
+    >       pedals: shared-pedals
+    >     gravel:
+    >       pedals: shared-pedals
+    >   - since: 2024-06-01
+    >     gravel:
+    >       pedals: null
+    > END
+
+    $ strava-gear <<END
+    > name,gear_id,start_date,moving_time,distance,total_elevation_gain
+    > Road Ride 1,road,2024-01-01,3600,10000,100
+    > Gravel Ride 1,gravel,2024-01-02,3600,15000,200
+    > Road Ride 2,road,2024-07-01,3600,20000,300
+    > Gravel Ride 2,gravel,2024-07-02,3600,25000,400
+    > END
+    bike,role,id,name,km,hour,first … last
+    road,pedals,shared-pedals,shared-pedals,45.0,3.0,2024-01-01 … 2024-07-01
+
+Moving component (different rules) still works as before:
+
+    $ cat >rules.yaml <<END
+    > rules:
+    >   - road:
+    >       pedals: the-pedals
+    >   - since: 2024-06-01
+    >     gravel:
+    >       pedals: the-pedals
+    > END
+
+    $ strava-gear <<END
+    > name,gear_id,start_date,moving_time,distance,total_elevation_gain
+    > Road Ride,road,2024-01-01,3600,10000,100
+    > Gravel Ride,gravel,2024-07-01,3600,15000,200
+    > END
+    bike,role,id,name,km,hour,first … last
+    gravel,pedals,the-pedals,the-pedals,25.0,2.0,2024-01-01 … 2024-07-01
+

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -44,9 +44,13 @@ def test_rule():
     assert Rule(hashtags={'#b1': {'c': 'c1'}}) + Rule(hashtags={'#b1': {'c': 'c2'}}) == \
         Rule(hashtags={'#b1': {'c': 'c2'}})
 
-    # moving a component from one bike to another…
+    # moving a component from one bike to another (different rules)…
     assert Rule(bikes={'b1': {'c': 'c1', 'd': 'd1'}}) + Rule(bikes={'b2': {'c': 'c1'}}) == \
         Rule(bikes={'b1': {'d': 'd1'}, 'b2': {'c': 'c1'}})
+
+    # sharing a component across multiple bikes (same rule) - component stays on both
+    assert Rule(bikes={'b1': {'c': 'c1', 'd': 'd1'}}) + Rule(bikes={'b1': {'c': 'c1'}, 'b2': {'c': 'c1'}}) == \
+        Rule(bikes={'b1': {'c': 'c1', 'd': 'd1'}, 'b2': {'c': 'c1'}})
 
     # … hashtags aren't exclusive though
     assert Rule(hashtags={'#b1': {'c': 'c1', 'd': 'd1'}}) + Rule(hashtags={'#b2': {'c': 'c1'}}) == \

--- a/tests/test_input_rules.py
+++ b/tests/test_input_rules.py
@@ -136,4 +136,5 @@ def test_check_component_duplicities():
 
     assert check_component_duplicities(bikes={'b1': {'r1': 'c1'}}) == set([])
     assert check_component_duplicities(bikes={'b1': {'r1': 'c1', 'r2': 'c1'}}) == set(['c1'])
-    assert check_component_duplicities(bikes={'b1': {'r1': 'c1'}, 'b2': {'r1': 'c1'}}) == set(['c1'])
+    # same component on multiple bikes is now allowed (shared components)
+    assert check_component_duplicities(bikes={'b1': {'r1': 'c1'}, 'b2': {'r1': 'c1'}}) == set([])


### PR DESCRIPTION
Hi @liskin,

I have a use case for shared components between bikes in Strava. For example: may main road bike is also my indoor bike and I want to keep track of the shared usage of a chain, while I want to separate the usage of the cassettes that are mounted on the road wheel and on the turbo trainer.

Previously, I had set up two different chains with similar name and added up the mileage manually from strava-gear output. With this patch, I can assign the same chain to multiple bikes.

DISCLAIMER: I've used Claude Code to help me implement the change, I hope this is ok for you.

Thanks,

L

PR description:

Allow the same component to be assigned to multiple bikes simultaneously when defined in the same rule. Usage from all bikes is summed together.

- Change Component.assignment to assignments list
- Update Rule.__add__() to preserve shared components across bikes
- Update component_assignments() to return list per component
- Allow same component on multiple bikes in check_component_duplicities()
- Generate one report row per (component, assignment) pair

Sharing is implicit when the same component appears on multiple bikes within the same rule. Use explicit null to stop sharing.